### PR TITLE
fix: move `heatingModeStatus` out of `diagnostic` category

### DIFF
--- a/custom_components/renogy/const.py
+++ b/custom_components/renogy/const.py
@@ -53,7 +53,6 @@ BINARY_SENSORS: Final[dict[str, BinarySensorEntityDescription]] = {
     "heatingModeStatus": BinarySensorEntityDescription(
         name="Heating Mode",
         key="heatingModeStatus",
-        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "state": BinarySensorEntityDescription(
         name="State",


### PR DESCRIPTION
just a cosmetic change