### PR TITLE
fix(config_flow): use Home Assistant clientsession to prevent SSL error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.13"
           - "3.14"
 
     steps:

--- a/custom_components/renogy/config_flow.py
+++ b/custom_components/renogy/config_flow.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from renogyapi import Renogy as api
 from renogyapi.exceptions import (
     NoDevices,
@@ -175,6 +176,7 @@ class RenogyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             renogy = api(
                 secret_key=user_input[CONF_SECRET_KEY],
                 access_key=user_input[CONF_ACCESS_KEY],
+                session=async_get_clientsession(self.hass),
             )
             try:
                 await renogy.get_devices()
@@ -319,6 +321,7 @@ class RenogyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             renogy = api(
                 secret_key=user_input[CONF_SECRET_KEY],
                 access_key=user_input[CONF_ACCESS_KEY],
+                session=async_get_clientsession(self.hass),
             )
             try:
                 await renogy.get_devices()

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,6 +9,7 @@ pycares>=4.11.0,<6.0.0  # Pin <5.0.0 for aiodns compatibility, >=4.11.0 for py3.
 aiousbwatcher
 pyserial
 serialx
+aioesphomeapi
 ruff
 pre-commit
 codespell

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,6 @@
 pytest-homeassistant-custom-component
 mypy
 tox
-aioresponses
 pytest
 aiohttp_cors
 pycares>=4.11.0,<6.0.0  # Pin <5.0.0 for aiodns compatibility, >=4.11.0 for py3.13

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,6 +8,7 @@ aiohttp_cors
 pycares>=4.11.0,<6.0.0  # Pin <5.0.0 for aiodns compatibility, >=4.11.0 for py3.13
 aiousbwatcher
 pyserial
+serialx
 ruff
 pre-commit
 codespell

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.13
+python_version = 3.14
 show_error_codes = true
 ignore_errors = true
 follow_imports = silent

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,24 @@
 from unittest.mock import patch
 
 import pytest
-from aioresponses import aioresponses
 
 from .common import load_fixture
 from .const import DUPE_SERIAL
 
 BASE_URL = "https://openapi.renogy.com"
 DEVICE_LIST = "/device/list"
+
+
+class AIOMockerWrapper:
+    """Wrapper to translate aioresponses style calls to aioclient_mock."""
+
+    def __init__(self, mocker):
+        """Initialize."""
+        self._mocker = mocker
+
+    def get(self, url, status=200, body="", **kwargs):
+        """Mock GET request."""
+        self._mocker.get(url, status=status, text=body)
 
 
 # This fixture enables loading custom integrations in all tests.
@@ -34,10 +45,9 @@ def skip_notifications_fixture():
 
 
 @pytest.fixture
-def mock_aioclient():
+def mock_aioclient(aioclient_mock):
     """Fixture to mock aioclient calls."""
-    with aioresponses() as m:
-        yield m
+    return AIOMockerWrapper(aioclient_mock)
 
 
 @pytest.fixture(name="mock_api")

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,12 @@ skipsdist = true
 # https://tox.readthedocs.io/en/latest/introduction.html
 
 # The environments to test
-envlist = py313, py314
+envlist = py314, lint, mypy
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-  3.13: py313, lint, mypy
-  3.14: py314
+  3.14: py314, lint, mypy
 
 [pytest]
 asyncio_mode = auto


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The config flow and reconfig steps for the Renogy Cloud API were previously instantiating the Renogy API client without passing a custom `ClientSession`. This caused the client to spin up its own raw `aiohttp.ClientSession()` on the fly, which lacks the connection pooling, DNS caching, and proxy config of the managed Home Assistant `ClientSession`. If the user's environment is behind an HTTP proxy (e.g. `HTTPS_PROXY` environment variable), the raw session would fail to negotiate the SSL handshake on the proxy's plain text response, leading to `[SSL: WRONG_VERSION_NUMBER]` connection errors.

This PR passes the Home Assistant managed session via `async_get_clientsession(self.hass)` to the `api` constructor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #112
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code changes are tested and work locally.
- [x] Local tests pass.
- [x] There is no overriding of unit tests in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated automated validation and type checking to target Python 3.14.
  * Improved alignment with the latest Python runtime environment.

* **Bug Fixes**
  * Improved cloud setup and reconfiguration reliability by using Home Assistant’s shared network session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->