### PR TITLE
chore(agents): add agent skills for home assistant and renogy BLE standards

### DIFF
--- a/.agents/skills/ha_modernization_standards/SKILL.md
+++ b/.agents/skills/ha_modernization_standards/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: Home Assistant Modernization Standards
+description: Guidelines for adhering to modern Home Assistant lifecycle and component structure rules (like runtime_data).
+---
+
+# Home Assistant Modernization Standards
+
+This skill ensures that all changes and additions to this integration align with modern Home Assistant development practices, lifecycle methods, and architecture requirements.
+
+## Guidelines
+
+### 1. Replaces `hass.data` with `ConfigEntry.runtime_data`
+* For Home Assistant core version compatibility, always store active runtime data (like the coordinator instance) using the typed `ConfigEntry.runtime_data` pattern instead of storing objects globally in `hass.data[DOMAIN]`.
+
+### 2. Async Lifecycle & Config Entry Setup
+* During config entry setup (`async_setup_entry`), ensure any network-dependent actions (like connecting to the api/device) are managed cleanly.
+* Do not perform blocking, synchronous updates directly during setup. Leverage `DataUpdateCoordinator` and handle first-refresh behavior carefully to avoid triggering Home Assistant's configuration entry setup timeouts (`CancelledError`).
+
+### 3. Graceful Property Access
+* All sensor and binary_sensor entities should handle situations where the coordinator has no data (`self.coordinator.data is None`) gracefully. Return appropriate defaults (e.g. `None` or `0`) rather than raising a `TypeError` or `AttributeError`.

--- a/.agents/skills/renogy_ble_monitoring/SKILL.md
+++ b/.agents/skills/renogy_ble_monitoring/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: Renogy BLE Client Guidelines
+description: Guidelines for managing and writing tests/code for the custom Renogy BLE Client communication.
+---
+
+# Renogy BLE Client Guidelines
+
+This skill ensures that all changes and additions to the BLE communication within the `ha-renogy` integration follow safe, async, and correct patterns when interfacing with BLE devices using `bleak` and Home Assistant's `bluetooth` component.
+
+## Guidelines
+
+### 1. BLE Connection Management
+* Never perform blocking operations on the event loop. Always use async methods for connecting, disconnecting, reading, and writing to characteristics.
+* Implement robust retry/reconnection logic when connection attempts fail. Ensure the client releases any active connections or handles `BleakError` / `BleakDBusError` exceptions cleanly.
+* Leverage `async_register_callback` or the bluetooth integration's connection tracking hooks to clean up BLE client instances when the config entry is unloaded.
+
+### 2. BLE Notifications and Subscriptions
+* Keep notification handlers/callbacks lightweight. Delegate any complex parsing or state changes to async tasks or dispatcher signals rather than executing them inside the raw Bluetooth callback thread/context.
+* Ensure characteristics notifications are successfully unsubscribed on disconnect/unload.
+
+### 3. Testing BLE Clients
+* When testing BLE components, mock the `bleak` client calls and Home Assistant's `bluetooth` scanner components.
+* Ensure all BLE tests yield control back to the event loop so that connection hooks can trigger mock events properly.


### PR DESCRIPTION
## Description

This PR adds repository-specific agent skills to `.agents/skills/` to document and enforce project standards and best practices for AI coding assistants working in this repository:
1. **Home Assistant Modernization Standards**: Codifies modern Home Assistant custom component requirements such as avoiding global storage in `hass.data` (preferring `ConfigEntry.runtime_data`), managing config entry setup, and handling properties gracefully.
2. **Renogy BLE Client Guidelines**: Details best practices for BLE communication using Bleak, handling reconnections, handling callbacks, and setting up BLE tests.

## Type of change

- [x] Code quality / Refactoring
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings